### PR TITLE
Fix 'page not found' error by removing requireInterstitial

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -216,11 +216,15 @@ ${slugs
       let body = await response.text();
       // Rewrite domain info to prevent redirect
       body = rewriteDomainInBody(body);
-      // Also rewrite specific fields that cause redirects
+      // Also rewrite specific fields that cause redirects or interstitial pages
       try {
         const json = JSON.parse(body);
         if (json.spaceDomain) json.spaceDomain = MY_DOMAIN.split('.')[0];
         if (json.publicDomainName) json.publicDomainName = MY_DOMAIN;
+        // Remove requireInterstitial to prevent "page not found" error
+        delete json.requireInterstitial;
+        // Set requestedOnExternalDomain to false to avoid external domain checks
+        json.requestedOnExternalDomain = false;
         body = JSON.stringify(json);
       } catch (e) {
         // If JSON parsing fails, continue with string replacement


### PR DESCRIPTION
## Summary

This PR fixes the "This page couldn't be found" error that occurs when accessing Notion pages through custom domains.

## Problem

After applying PR #4, pages on `kazuma.tyna.ninja` still show "This page couldn't be found" error instead of the actual Notion content.

## Root Cause

Analysis of the HAR file (`kazuma.tyna.ninja.har`) revealed that the `getPublicPageData` API response contains:

```json
{
  "requireInterstitial": "https://kazuma.tyna.ninja/9cfb389d668b4ec59096a66be67c5e9c",
  "requestedOnExternalDomain": true
}
```

When Notion's client-side JavaScript detects these fields, it shows an interstitial/error page instead of rendering the actual content. This is Notion's protection mechanism for external domain access.

## Solution

Modify the `getPublicPageData` response processing to:

1. **Delete `requireInterstitial` field** - Prevents the interstitial page from being triggered
2. **Set `requestedOnExternalDomain` to `false`** - Bypasses external domain checks

## Testing

Tested with HAR file from `kazuma.tyna.ninja` accessing Notion page `9cfb389d668b4ec59096a66be67c5e9c`.

## Related

- PR #4 - Initial fix for redirect to notion.site domain
- [stephenou/fruitionsite#292](https://github.com/stephenou/fruitionsite/issues/292)