### PR TITLE
Update image resizing options to align with latest Cloudflare API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -627,9 +627,11 @@ export default function App() {
                     value={optionImage.imageFormat ?? ""}
                     onChange={handleSelectChange}
                   >
+                    <MenuItem value="auto">auto (recommended)</MenuItem>
                     <MenuItem value="avif">avif</MenuItem>
                     <MenuItem value="webp">webp</MenuItem>
-                    <MenuItem value="json">json</MenuItem>
+                    <MenuItem value="jpeg">jpeg</MenuItem>
+                    <MenuItem value="png">png</MenuItem>
                   </Select>
                 </FormControl>
                 <FormControl
@@ -664,15 +666,60 @@ export default function App() {
                   size="small"
                   sx={{ m: 0.5, width: "12ch" }}
                 />
+                <FormControl
+                  variant="filled"
+                  size="small"
+                  sx={{ m: 0.5, minWidth: "18ch" }}
+                >
+                  <InputLabel id="imageMetadataLabel">Metadata</InputLabel>
+                  <Select
+                    labelId="imageMetadataLabel"
+                    label="Metadata"
+                    name="imageMetadata"
+                    value={optionImage.imageMetadata ?? ""}
+                    onChange={handleSelectChange}
+                  >
+                    <MenuItem value="none">none (default)</MenuItem>
+                    <MenuItem value="keep">keep</MenuItem>
+                    <MenuItem value="copyright">copyright</MenuItem>
+                  </Select>
+                </FormControl>
+                <FormControlLabel
+                  control={
+                    <Radio
+                      checked={optionImage.imageAnim !== false}
+                      onChange={() => {
+                        setOptionImage({ ...optionImage, imageAnim: true });
+                        setCopied(false);
+                      }}
+                      size="small"
+                    />
+                  }
+                  label="Anim: On"
+                  sx={{ ml: 1 }}
+                />
+                <FormControlLabel
+                  control={
+                    <Radio
+                      checked={optionImage.imageAnim === false}
+                      onChange={() => {
+                        setOptionImage({ ...optionImage, imageAnim: false });
+                        setCopied(false);
+                      }}
+                      size="small"
+                    />
+                  }
+                  label="Anim: Off"
+                />
               </Box>
               <Alert severity="info" sx={{ mt: 2 }}>
                 Enable{" "}
                 <Link
-                  href="https://developers.cloudflare.com/images/image-resizing/enable-image-resizing/"
+                  href="https://developers.cloudflare.com/images/transform-images/"
                   target="_blank"
                   rel="noreferrer"
                 >
-                  Image Resizing
+                  Image Transformations
                 </Link>{" "}
                 in your Cloudflare dashboard to use this feature.
               </Alert>


### PR DESCRIPTION
## Summary

This PR updates the image resizing functionality to align with the latest Cloudflare Image Transformations API (as of 2025).

## Changes

### Removed
- **`polish` option** - This option has been deprecated/removed from Cloudflare's API. Polish functionality is now integrated into Image Resizing.

### Added
- **`format: "auto"` option** - Allows automatic format negotiation based on the client's Accept header. This is now the recommended default.
- **`anim` option** - Controls whether animation frames are preserved from input files (GIF, WebP). Setting to `false` reduces animations to still images, which is useful for large GIF processing.
- **`metadata` option** - Controls image metadata handling:
  - `none` (default): Strip all metadata
  - `keep`: Preserve all metadata
  - `copyright`: Keep only copyright-related metadata
- **`jpeg` and `png` format options** - Added missing format options to the UI

### Improved
- Dynamic image options building - Only includes defined options in the request, avoiding empty string issues
- Updated documentation link to current Cloudflare docs (`/images/transform-images/`)
- Set sensible defaults (`format: auto`, `fit: scale-down`)

## References

- [Cloudflare Image Transformations via Workers](https://developers.cloudflare.com/images/transform-images/transform-via-workers/)
- [Cloudflare Images Changelog - Feb 2025](https://developers.cloudflare.com/changelog/2025-02-21-images-bindings-in-workers/)

## Testing

- [x] Build passes
- [ ] Manual testing with Cloudflare Worker deployment
