### PR TITLE
Add customization features: favicon, GA4, header HTML, 404 page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,9 @@ import code, {
   PageMetadata,
   StructuredDataOptions,
   BrandingOptions,
+  AnalyticsOptions,
+  CustomHtmlOptions,
+  Custom404Options,
 } from "./code";
 import "./styles.css";
 
@@ -146,10 +149,20 @@ export default function App() {
     siteName: "",
     brandReplacement: "",
     twitterHandle: "",
+    faviconUrl: "",
   });
   const [slugMetadataExpanded, setSlugMetadataExpanded] = useState<
     Record<number, boolean>
   >({});
+  const [analytics, setAnalytics] = useState<AnalyticsOptions>({
+    googleTagId: "",
+  });
+  const [customHtml, setCustomHtml] = useState<CustomHtmlOptions>({
+    headerHtml: "",
+  });
+  const [custom404, setCustom404] = useState<Custom404Options>({
+    notionUrl: "",
+  });
 
   function createInputHandler<T>(
     setter: React.Dispatch<React.SetStateAction<T>>,
@@ -248,6 +261,39 @@ export default function App() {
     setCopied(false);
   }
 
+  function handleAnalyticsChange(
+    field: keyof AnalyticsOptions,
+    value: string,
+  ): void {
+    setAnalytics({
+      ...analytics,
+      [field]: value,
+    });
+    setCopied(false);
+  }
+
+  function handleCustomHtmlChange(
+    field: keyof CustomHtmlOptions,
+    value: string,
+  ): void {
+    setCustomHtml({
+      ...customHtml,
+      [field]: value,
+    });
+    setCopied(false);
+  }
+
+  function handleCustom404Change(
+    field: keyof Custom404Options,
+    value: string,
+  ): void {
+    setCustom404({
+      ...custom404,
+      [field]: value,
+    });
+    setCopied(false);
+  }
+
   function toggleSlugMetadata(index: number): void {
     setSlugMetadataExpanded({
       ...slugMetadataExpanded,
@@ -310,6 +356,9 @@ export default function App() {
     pageMetadata,
     structuredData,
     branding,
+    analytics,
+    customHtml,
+    custom404,
   };
 
   const script = noError ? code(codeData) : undefined;
@@ -773,6 +822,93 @@ export default function App() {
                     handleBrandingChange("twitterHandle", e.target.value)
                   }
                   value={branding.twitterHandle}
+                  variant="outlined"
+                  size="small"
+                />
+                <TextField
+                  fullWidth
+                  label="Custom Favicon URL"
+                  margin="dense"
+                  placeholder="https://example.com/favicon.ico"
+                  helperText="Replaces Notion's default favicon (.ico, .png, .svg)"
+                  onChange={(e) =>
+                    handleBrandingChange("faviconUrl", e.target.value)
+                  }
+                  value={branding.faviconUrl}
+                  variant="outlined"
+                  size="small"
+                />
+              </Box>
+
+              <Box sx={{ mt: 3, pt: 2, borderTop: 1, borderColor: "grey.300" }}>
+                <Typography
+                  variant="subtitle2"
+                  color="text.secondary"
+                  gutterBottom
+                >
+                  Analytics
+                </Typography>
+                <TextField
+                  fullWidth
+                  label="Google Analytics Measurement ID"
+                  margin="dense"
+                  placeholder="G-XXXXXXXXXX"
+                  helperText="Your GA4 Measurement ID for automatic tracking"
+                  onChange={(e) =>
+                    handleAnalyticsChange("googleTagId", e.target.value)
+                  }
+                  value={analytics.googleTagId}
+                  variant="outlined"
+                  size="small"
+                />
+              </Box>
+
+              <Box sx={{ mt: 3, pt: 2, borderTop: 1, borderColor: "grey.300" }}>
+                <Typography
+                  variant="subtitle2"
+                  color="text.secondary"
+                  gutterBottom
+                >
+                  Custom Header HTML
+                </Typography>
+                <TextField
+                  fullWidth
+                  label="Header HTML"
+                  margin="dense"
+                  multiline
+                  minRows={3}
+                  placeholder={`<nav class="site-nav">
+  <a href="/">Home</a>
+  <a href="/about">About</a>
+</nav>`}
+                  helperText="HTML injected at the top of page body (e.g., navigation, announcements)"
+                  onChange={(e) =>
+                    handleCustomHtmlChange("headerHtml", e.target.value)
+                  }
+                  value={customHtml.headerHtml}
+                  variant="outlined"
+                  size="small"
+                />
+              </Box>
+
+              <Box sx={{ mt: 3, pt: 2, borderTop: 1, borderColor: "grey.300" }}>
+                <Typography
+                  variant="subtitle2"
+                  color="text.secondary"
+                  gutterBottom
+                >
+                  Custom 404 Page
+                </Typography>
+                <TextField
+                  fullWidth
+                  label="404 Page Notion URL"
+                  margin="dense"
+                  placeholder={DEFAULT_NOTION_URL}
+                  helperText="Notion page to display when a page is not found"
+                  onChange={(e) =>
+                    handleCustom404Change("notionUrl", e.target.value)
+                  }
+                  value={custom404.notionUrl}
                   variant="outlined"
                   size="small"
                 />


### PR DESCRIPTION
## Summary

This PR implements multiple customization features requested in the following issues:

### Features Implemented

#### Custom Favicon Support (Closes #16) - priority: high
- New `faviconUrl` option in branding settings
- `LinkRewriter` removes Notion's default favicon links
- `HeadRewriter` adds custom favicon, shortcut icon, and apple-touch-icon
- Supports .ico, .png, .svg formats

#### Google Analytics 4 Built-in Support (Closes #14) - priority: medium
- New `analytics.googleTagId` option
- Automatic GA4 script injection in `HeadRewriter`
- Simple configuration: just enter your GA4 Measurement ID (G-XXXXXXXXXX)

#### Custom HTML Header Injection (Closes #20) - priority: medium
- New `customHtml.headerHtml` option
- `BodyRewriter` prepends custom HTML at top of body
- Use cases: navigation bars, announcement banners, CTAs

#### Custom 404 Page Support (Closes #12) - priority: medium
- New `custom404.notionUrl` option
- `fetchAndApply` returns custom Notion page content with 404 status
- Maintains brand consistency for error pages

## UI Changes

All new features are accessible in the Advanced Settings panel:
- **Branding & Social**: Custom Favicon URL field added
- **Analytics**: New section with Google Analytics Measurement ID field
- **Custom Header HTML**: New section with multiline textarea for HTML
- **Custom 404 Page**: New section with Notion URL field

## Testing

- [x] Build succeeds (`npm run build`)
- [x] All features generate correct Worker script code
- [x] UI properly shows/hides in Advanced Settings