### PR TITLE
Add AI crawler attribution meta tags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import code, {
   PageMetadata,
   StructuredDataOptions,
   BrandingOptions,
+  SeoOptions,
   AnalyticsOptions,
   CustomHtmlOptions,
   Custom404Options,
@@ -150,6 +151,9 @@ export default function App() {
     brandReplacement: "",
     twitterHandle: "",
     faviconUrl: "",
+  });
+  const [seo, setSeo] = useState<SeoOptions>({
+    aiAttribution: "",
   });
   const [slugMetadataExpanded, setSlugMetadataExpanded] = useState<
     Record<number, boolean>
@@ -261,6 +265,14 @@ export default function App() {
     setCopied(false);
   }
 
+  function handleSeoChange(field: keyof SeoOptions, value: string): void {
+    setSeo({
+      ...seo,
+      [field]: value,
+    });
+    setCopied(false);
+  }
+
   function handleAnalyticsChange(
     field: keyof AnalyticsOptions,
     value: string,
@@ -356,6 +368,7 @@ export default function App() {
     pageMetadata,
     structuredData,
     branding,
+    seo,
     analytics,
     customHtml,
     custom404,
@@ -835,6 +848,29 @@ export default function App() {
                     handleBrandingChange("faviconUrl", e.target.value)
                   }
                   value={branding.faviconUrl}
+                  variant="outlined"
+                  size="small"
+                />
+              </Box>
+
+              <Box sx={{ mt: 3, pt: 2, borderTop: 1, borderColor: "grey.300" }}>
+                <Typography
+                  variant="subtitle2"
+                  color="text.secondary"
+                  gutterBottom
+                >
+                  SEO & AI Attribution
+                </Typography>
+                <TextField
+                  fullWidth
+                  label="AI Attribution"
+                  margin="dense"
+                  placeholder="Your Name - yourdomain.com"
+                  helperText="Attribution text for AI crawlers (ChatGPT, Claude, Perplexity, etc.)"
+                  onChange={(e) =>
+                    handleSeoChange("aiAttribution", e.target.value)
+                  }
+                  value={seo.aiAttribution}
                   variant="outlined"
                   size="small"
                 />

--- a/src/code.ts
+++ b/src/code.ts
@@ -30,6 +30,10 @@ export interface BrandingOptions {
   faviconUrl?: string;
 }
 
+export interface SeoOptions {
+  aiAttribution?: string;
+}
+
 export interface AnalyticsOptions {
   googleTagId?: string;
 }
@@ -55,6 +59,7 @@ export interface CodeData {
   pageMetadata: Record<string, PageMetadata>;
   structuredData: StructuredDataOptions;
   branding: BrandingOptions;
+  seo: SeoOptions;
   analytics: AnalyticsOptions;
   customHtml: CustomHtmlOptions;
   custom404: Custom404Options;
@@ -84,6 +89,7 @@ export default function code(data: CodeData): string {
     pageMetadata,
     structuredData,
     branding,
+    seo,
     analytics,
     customHtml,
     custom404,
@@ -140,19 +146,25 @@ ${slugs
   const FAVICON_URL = '${branding?.faviconUrl || ""}';
 
   /*
-   * Step 3.4: analytics configuration (optional)
+   * Step 3.4: SEO configuration (optional)
+   * AI attribution for proper citation in AI-generated content
+   */
+  const AI_ATTRIBUTION = '${seo?.aiAttribution || ""}';
+
+  /*
+   * Step 3.5: analytics configuration (optional)
    * Add your Google Analytics 4 Measurement ID for built-in tracking
    */
   const GOOGLE_TAG_ID = '${analytics?.googleTagId || ""}';
 
   /*
-   * Step 3.5: custom HTML header injection (optional)
+   * Step 3.6: custom HTML header injection (optional)
    * Add custom HTML to the top of the page body (e.g., navigation, announcements)
    */
   const CUSTOM_HEADER = \`${customHtml?.headerHtml || ""}\`;
 
   /*
-   * Step 3.6: custom 404 page configuration (optional)
+   * Step 3.7: custom 404 page configuration (optional)
    * Specify a Notion page ID to display when a page is not found
    */
   const CUSTOM_404_PAGE_ID = '${custom404?.notionUrl ? getId(custom404.notionUrl) : ""}';
@@ -522,6 +534,12 @@ ${slugs
       if (TWITTER_HANDLE !== '') {
         element.append(\`<meta name="twitter:site" content="\${TWITTER_HANDLE}">\`, { html: true });
         element.append(\`<meta name="twitter:creator" content="\${TWITTER_HANDLE}">\`, { html: true });
+      }
+
+      // Add AI crawler attribution meta tags (Issue #13)
+      if (AI_ATTRIBUTION !== '') {
+        element.append(\`<meta name="ai:source_url" content="\${canonicalUrl}">\`, { html: true });
+        element.append(\`<meta name="ai:source_attribution" content="\${AI_ATTRIBUTION}">\`, { html: true });
       }
 
       // Add JSON-LD structured data for rich search results (Issue #10)


### PR DESCRIPTION
## Summary

Add meta tags for AI crawler attribution to help AI systems (ChatGPT, Claude, Perplexity, etc.) properly attribute content when citing from the site.

## Changes

- Add `SeoOptions` interface with `aiAttribution` field
- Add "AI Attribution" input field in Advanced Settings under "SEO & AI Attribution" section
- Generate `ai:source_url` and `ai:source_attribution` meta tags in HeadRewriter when configured

## Generated Meta Tags

When AI Attribution is configured, the following meta tags are added:

```html
<meta name="ai:source_url" content="https://yourdomain.com/page-slug">
<meta name="ai:source_attribution" content="Your Name - yourdomain.com">
```

## Benefits

- Proper attribution in AI-generated content
- Brand recognition in AI responses
- Future-proofing for evolving AI citation standards

Closes #13