### PR TITLE
Add Cache-Control header optimization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import code, {
   BrandingOptions,
   SeoOptions,
   AnalyticsOptions,
+  CachingOptions,
   CustomHtmlOptions,
   Custom404Options,
   SubdomainRedirect,
@@ -161,6 +162,12 @@ export default function App() {
   >({});
   const [analytics, setAnalytics] = useState<AnalyticsOptions>({
     googleTagId: "",
+  });
+  const [caching, setCaching] = useState<CachingOptions>({
+    enabled: false,
+    htmlTtl: 60,
+    staticAssetsTtl: 86400,
+    imageTtl: 604800,
   });
   const [customHtml, setCustomHtml] = useState<CustomHtmlOptions>({
     headerHtml: "",
@@ -288,6 +295,17 @@ export default function App() {
     setCopied(false);
   }
 
+  function handleCachingChange(
+    field: keyof CachingOptions,
+    value: boolean | number,
+  ): void {
+    setCaching({
+      ...caching,
+      [field]: value,
+    });
+    setCopied(false);
+  }
+
   function handleCustomHtmlChange(
     field: keyof CustomHtmlOptions,
     value: string,
@@ -400,6 +418,7 @@ export default function App() {
     branding,
     seo,
     analytics,
+    caching,
     customHtml,
     custom404,
     subdomainRedirects,
@@ -928,6 +947,78 @@ export default function App() {
                   variant="outlined"
                   size="small"
                 />
+              </Box>
+
+              <Box sx={{ mt: 3, pt: 2, borderTop: 1, borderColor: "grey.300" }}>
+                <Stack
+                  direction="row"
+                  alignItems="center"
+                  justifyContent="space-between"
+                >
+                  <Box>
+                    <Typography variant="subtitle2" color="text.secondary">
+                      Cache-Control Headers
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Improve performance with browser caching
+                    </Typography>
+                  </Box>
+                  <Switch
+                    checked={caching.enabled}
+                    onChange={(e) =>
+                      handleCachingChange("enabled", e.target.checked)
+                    }
+                  />
+                </Stack>
+                <Collapse in={caching.enabled} timeout="auto" unmountOnExit>
+                  <Box sx={{ mt: 2 }}>
+                    <TextField
+                      fullWidth
+                      type="number"
+                      label="HTML Page TTL (seconds)"
+                      margin="dense"
+                      placeholder="60"
+                      helperText="Cache duration for HTML pages (default: 60s)"
+                      onChange={(e) =>
+                        handleCachingChange("htmlTtl", Number(e.target.value))
+                      }
+                      value={caching.htmlTtl}
+                      variant="outlined"
+                      size="small"
+                    />
+                    <TextField
+                      fullWidth
+                      type="number"
+                      label="Static Assets TTL (seconds)"
+                      margin="dense"
+                      placeholder="86400"
+                      helperText="Cache duration for JS, CSS, fonts (default: 1 day)"
+                      onChange={(e) =>
+                        handleCachingChange(
+                          "staticAssetsTtl",
+                          Number(e.target.value),
+                        )
+                      }
+                      value={caching.staticAssetsTtl}
+                      variant="outlined"
+                      size="small"
+                    />
+                    <TextField
+                      fullWidth
+                      type="number"
+                      label="Image TTL (seconds)"
+                      margin="dense"
+                      placeholder="604800"
+                      helperText="Cache duration for images (default: 1 week)"
+                      onChange={(e) =>
+                        handleCachingChange("imageTtl", Number(e.target.value))
+                      }
+                      value={caching.imageTtl}
+                      variant="outlined"
+                      size="small"
+                    />
+                  </Box>
+                </Collapse>
               </Box>
 
               <Box sx={{ mt: 3, pt: 2, borderTop: 1, borderColor: "grey.300" }}>


### PR DESCRIPTION
## Summary
Add configurable Cache-Control headers to improve performance and reduce origin requests.

## Changes
- Add `CachingOptions` interface with `htmlTtl`, `staticAssetsTtl`, `imageTtl`
- Add `applyCacheHeaders` function to set Cache-Control based on content type
- Apply cache headers to JS, CSS, images, and HTML responses
- Add "Cache-Control Headers" section in Advanced Settings UI

## Implementation Details
Cache headers are applied based on content type:
- **Static assets** (JS, CSS, fonts): `public, max-age={TTL}, immutable`
- **Images**: `public, max-age={TTL}`
- **HTML pages**: `public, max-age={TTL}, stale-while-revalidate=60`

Default TTL values:
- HTML: 60 seconds
- Static assets: 86400 seconds (1 day)
- Images: 604800 seconds (1 week)

## UI Changes
Added "Cache-Control Headers" section with:
- Enable/disable toggle
- HTML Page TTL input
- Static Assets TTL input
- Image TTL input

## Benefits
- Faster page loads for returning visitors
- Reduced bandwidth costs
- Better Lighthouse performance scores
- Less load on Notion servers

Closes #33