### PR TITLE
Enhance Open Graph tags for better link previews

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import code, {
   PageMetadata,
   StructuredDataOptions,
   BrandingOptions,
+  SocialPreviewOptions,
   SeoOptions,
   AnalyticsOptions,
   CustomHtmlOptions,
@@ -152,6 +153,13 @@ export default function App() {
     brandReplacement: "",
     twitterHandle: "",
     faviconUrl: "",
+  });
+  const [socialPreview, setSocialPreview] = useState<SocialPreviewOptions>({
+    defaultImage: "",
+    imageWidth: 1200,
+    imageHeight: 630,
+    twitterCardType: "summary_large_image",
+    locale: "",
   });
   const [seo, setSeo] = useState<SeoOptions>({
     aiAttribution: "",
@@ -264,6 +272,17 @@ export default function App() {
   ): void {
     setBranding({
       ...branding,
+      [field]: value,
+    });
+    setCopied(false);
+  }
+
+  function handleSocialPreviewChange(
+    field: keyof SocialPreviewOptions,
+    value: string | number,
+  ): void {
+    setSocialPreview({
+      ...socialPreview,
       [field]: value,
     });
     setCopied(false);
@@ -398,6 +417,7 @@ export default function App() {
     pageMetadata,
     structuredData,
     branding,
+    socialPreview,
     seo,
     analytics,
     customHtml,
@@ -879,6 +899,99 @@ export default function App() {
                     handleBrandingChange("faviconUrl", e.target.value)
                   }
                   value={branding.faviconUrl}
+                  variant="outlined"
+                  size="small"
+                />
+              </Box>
+
+              <Box sx={{ mt: 3, pt: 2, borderTop: 1, borderColor: "grey.300" }}>
+                <Typography
+                  variant="subtitle2"
+                  color="text.secondary"
+                  gutterBottom
+                >
+                  Social Preview
+                </Typography>
+                <TextField
+                  fullWidth
+                  label="Default OG Image URL"
+                  margin="dense"
+                  placeholder="https://example.com/og-image.jpg"
+                  helperText="Fallback image for pages without a specific OG image"
+                  onChange={(e) =>
+                    handleSocialPreviewChange("defaultImage", e.target.value)
+                  }
+                  value={socialPreview.defaultImage}
+                  variant="outlined"
+                  size="small"
+                />
+                <Stack direction="row" spacing={2}>
+                  <TextField
+                    type="number"
+                    label="Image Width"
+                    margin="dense"
+                    placeholder="1200"
+                    helperText="og:image:width"
+                    onChange={(e) =>
+                      handleSocialPreviewChange(
+                        "imageWidth",
+                        Number(e.target.value),
+                      )
+                    }
+                    value={socialPreview.imageWidth}
+                    variant="outlined"
+                    size="small"
+                    sx={{ flex: 1 }}
+                  />
+                  <TextField
+                    type="number"
+                    label="Image Height"
+                    margin="dense"
+                    placeholder="630"
+                    helperText="og:image:height"
+                    onChange={(e) =>
+                      handleSocialPreviewChange(
+                        "imageHeight",
+                        Number(e.target.value),
+                      )
+                    }
+                    value={socialPreview.imageHeight}
+                    variant="outlined"
+                    size="small"
+                    sx={{ flex: 1 }}
+                  />
+                </Stack>
+                <FormControl fullWidth size="small" margin="dense">
+                  <InputLabel id="twitterCardTypeLabel">
+                    Twitter Card Type
+                  </InputLabel>
+                  <Select
+                    labelId="twitterCardTypeLabel"
+                    label="Twitter Card Type"
+                    value={socialPreview.twitterCardType}
+                    onChange={(e) =>
+                      handleSocialPreviewChange(
+                        "twitterCardType",
+                        e.target.value,
+                      )
+                    }
+                  >
+                    <MenuItem value="summary_large_image">
+                      summary_large_image (recommended)
+                    </MenuItem>
+                    <MenuItem value="summary">summary</MenuItem>
+                  </Select>
+                </FormControl>
+                <TextField
+                  fullWidth
+                  label="Locale"
+                  margin="dense"
+                  placeholder="en_US, ja_JP, etc."
+                  helperText="og:locale for language targeting"
+                  onChange={(e) =>
+                    handleSocialPreviewChange("locale", e.target.value)
+                  }
+                  value={socialPreview.locale}
                   variant="outlined"
                   size="small"
                 />


### PR DESCRIPTION
## Summary
Enhance Open Graph and Twitter Card meta tags for better link previews in Slack, Discord, LinkedIn, and other platforms.

## Changes
- Add `SocialPreviewOptions` interface with `defaultImage`, `imageWidth`, `imageHeight`, `twitterCardType`, `locale`
- Add `og:type`, `og:image:width`, `og:image:height`, `og:locale` meta tags
- Add `twitter:card` meta tag with configurable type
- Support default OG image fallback for pages without specific images
- Add "Social Preview" UI section in Advanced Settings

## Implementation Details
New meta tags added:
- `og:type="website"` - Standard type for websites
- `og:image:width` / `og:image:height` - Image dimensions for better preview rendering
- `og:locale` - Language targeting (e.g., "en_US", "ja_JP")
- `twitter:card` - Configurable card type (summary or summary_large_image)

Default OG Image fallback:
- If page-specific `ogImage` is not set, uses `socialPreview.defaultImage` as fallback

## UI Changes
Added "Social Preview" section in Advanced Settings with:
- Default OG Image URL input
- Image Width/Height inputs
- Twitter Card Type selector
- Locale input

## Benefits
- Professional appearance in Slack/Discord/LinkedIn shares
- Consistent branding across social platforms
- Better click-through rates from social shares

Closes #34