### PR TITLE
Fix domain validation rejecting valid domains (#113)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ const DEFAULT_NOTION_URL =
   "https://succinct-scar-f20.notion.site/Sample-Web-Site-148f2fc322e74473a91fb4d90836e3ce";
 
 const DOMAIN_PATTERN =
-  /^((https:\/\/)|(http:\/\/))?[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+(\/)?$/;
+  /^(https?:\/\/)?([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}\/?$/;
 const NOTION_ID_PATTERN = /[0-9a-f]{32}/;
 
 function isValidDomain(domain: string): boolean {


### PR DESCRIPTION
## Problem

Closes #113.

`isValidDomain` rejected several valid domains, e.g.:

- `test.app1e.com` — a subdomain label containing a digit
- short labels like `x.io`

### Root cause

The previous regex only allowed alphanumerics in the **first** label and restricted every following label to **letters only** (`(?:\.[a-zA-Z]{2,})+`). So any non-first / non-TLD label containing a digit (`app1e`) was rejected, and the first label was forced to be at least 3 characters.

```
/^((https:\/\/)|(http:\/\/))?[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+(\/)?$/
```

## Fix

Validate each label independently (alphanumeric plus hyphens, no leading/trailing hyphen, max 63 chars) and restrict only the TLD to letters:

```
/^(https?:\/\/)?([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}\/?$/
```

## Verification

- Now valid: `test.app1e.com`, `app1e.kr`, `x.io`, `a.b.c.example.com`, `1example.com`, `https://test.app1e.com`, `example.co.uk`
- Still rejected: ``, `example.`, `-bad.com`, `bad-.com`, `a..b.com`, `example.123`
- `npm run build` passes